### PR TITLE
Feat: search before navigating

### DIFF
--- a/apps/admin-panel/app/ledger-account/ledger-account-page.stories.tsx
+++ b/apps/admin-panel/app/ledger-account/ledger-account-page.stories.tsx
@@ -1,15 +1,23 @@
 import type { Meta, StoryObj } from "@storybook/react"
+import { MockedProvider } from "@apollo/client/testing"
 
 import LedgerAccountIndexPage from "./page"
 
 const LedgerAccountIndexPageStory = () => {
-  return <LedgerAccountIndexPage />
+  return (
+    <MockedProvider>
+      <LedgerAccountIndexPage />
+    </MockedProvider>
+  )
 }
 
 const meta: Meta = {
   title: "Pages/LedgerAccounts",
   component: LedgerAccountIndexPageStory,
-  parameters: { layout: "fullscreen", nextjs: { appDirectory: true } },
+  parameters: {
+    layout: "fullscreen",
+    nextjs: { appDirectory: true },
+  },
 }
 
 export default meta

--- a/apps/admin-panel/app/ledger-account/page.tsx
+++ b/apps/admin-panel/app/ledger-account/page.tsx
@@ -1,13 +1,13 @@
 "use client"
 
-import React, { useState } from "react"
-
-import { useRouter } from "next/navigation"
+import { gql } from "@apollo/client"
+import React, { ChangeEvent, useState } from "react"
 
 import { Input } from "@lana/web/ui/input"
-import { Button } from "@lana/web/ui/button"
 import { Label } from "@lana/web/ui/label"
+import { LoadingSpinner } from "@lana/web/ui/loading-spinner"
 import { useTranslations } from "next-intl"
+import Link from "next/link"
 
 import {
   Card,
@@ -17,44 +17,124 @@ import {
   CardTitle,
 } from "@lana/web/ui/card"
 
+import { isUUID, debounce } from "@/lib/utils"
+import {
+  LedgerAccountNameByIdQuery,
+  LedgerAccountNameByCodeQuery,
+  useLedgerAccountNameByCodeLazyQuery,
+  useLedgerAccountNameByIdLazyQuery,
+} from "@/lib/graphql/generated"
+
+gql`
+  fragment LedgerAccountName on LedgerAccount {
+    id
+    name
+    code
+    ancestors {
+      id
+      name
+      code
+    }
+  }
+  query LedgerAccountNameByCode($code: String!) {
+    ledgerAccountByCode(code: $code) {
+      ...LedgerAccountName
+    }
+  }
+
+  query LedgerAccountNameById($id: UUID!) {
+    ledgerAccount(id: $id) {
+      ...LedgerAccountName
+    }
+  }
+`
+
 export default function LedgerAccount() {
   const t = useTranslations("LedgerAccounts")
-  const router = useRouter()
-  const [accountId, setAccountId] = useState("")
+  const [accountData, setAccountData] = useState<
+    | LedgerAccountNameByCodeQuery["ledgerAccountByCode"]
+    | LedgerAccountNameByIdQuery["ledgerAccount"]
+  >()
+  const [showErrorFetching, setShowErrorFetching] = useState(false)
+  const [loading, setLoading] = useState(false)
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    router.push(`/ledger-account/${accountId}`)
+  const [ledgerAccountByCodeQuery] = useLedgerAccountNameByCodeLazyQuery()
+  const [ledgerAccountByIdQuery] = useLedgerAccountNameByIdLazyQuery()
+
+  const handleLedgerAccountSearchChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    setLoading(true)
+    setShowErrorFetching(false)
+    const { value } = e.target
+
+    let accountQuery
+    if (isUUID(value)) {
+      accountQuery = await ledgerAccountByIdQuery({
+        variables: { id: value },
+      })
+    } else {
+      accountQuery = await ledgerAccountByCodeQuery({
+        variables: { code: value },
+      })
+    }
+    const { data, errors } = accountQuery
+
+    if (errors?.length || !data) {
+      setAccountData(null)
+      setShowErrorFetching(true)
+    } else {
+      if ("ledgerAccount" in data && data.ledgerAccount !== null) {
+        setAccountData(data.ledgerAccount)
+      } else if ("ledgerAccountByCode" in data && data.ledgerAccountByCode !== null) {
+        setAccountData(data.ledgerAccountByCode)
+      } else {
+        setAccountData(null)
+        setShowErrorFetching(true)
+      }
+    }
+    setLoading(false)
   }
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{t("title")}</CardTitle>
-        <CardDescription>{t("description")}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <form onSubmit={handleSubmit}>
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("title")}</CardTitle>
+          <CardDescription>{t("description")}</CardDescription>
+        </CardHeader>
+        <CardContent>
           <Label htmlFor="ledger-accounts">{t("form.labels.accountSearch")}</Label>
           <div className="flex flex-wrap md:flex-nowrap">
             <Input
               id="ledger-accounts"
               type="string"
               className="mr-2"
-              value={accountId}
-              onChange={(e) => {
-                const { value } = e.target
-                setAccountId(value)
-              }}
+              onChange={debounce((e) => handleLedgerAccountSearchChange(e), 150)}
               required
               placeholder={t("form.placeholders.accountSearch")}
               data-testid="search-ledger-accounts"
             />
-            <Button type="submit" className="mt-2 md:mt-0">
-              Search
-            </Button>
           </div>
-        </form>
-      </CardContent>
-    </Card>
+          {showErrorFetching && (
+            <p className="text-destructive text-sm">{t("form.errors.accountSearch")}</p>
+          )}
+        </CardContent>
+      </Card>
+      {loading && (
+        <Card className="mt-2 flex items-center justify-center p-4">
+          <LoadingSpinner />
+        </Card>
+      )}
+      {accountData && accountData.id && (
+        <Link href={`/ledger-account/${accountData.id}`}>
+          <Card className="mt-4 flex items-center  justify-between">
+            <CardHeader>
+              <CardTitle>{t("searchResult.title")}</CardTitle>
+              <CardDescription>{accountData?.name || accountData.code}</CardDescription>
+              {accountData.id}
+            </CardHeader>
+          </Card>
+        </Link>
+      )}
+    </>
   )
 }

--- a/apps/admin-panel/lib/graphql/generated/index.ts
+++ b/apps/admin-panel/lib/graphql/generated/index.ts
@@ -2490,6 +2490,22 @@ export type LedgerAccountQueryVariables = Exact<{
 
 export type LedgerAccountQuery = { __typename?: 'Query', ledgerAccount?: { __typename?: 'LedgerAccount', id: string, name: string, code?: any | null, ancestors: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, children: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }>, balanceRange: { __typename: 'BtcLedgerAccountBalanceRange', end: { __typename?: 'BtcLedgerAccountBalance', btcSettled: Satoshis } } | { __typename: 'UsdLedgerAccountBalanceRange', end: { __typename?: 'UsdLedgerAccountBalance', usdSettled: UsdCents } }, history: { __typename?: 'JournalEntryConnection', edges: Array<{ __typename?: 'JournalEntryEdge', cursor: string, node: { __typename?: 'JournalEntry', id: string, entryId: string, txId: string, entryType: string, description?: string | null, direction: DebitOrCredit, layer: Layer, createdAt: any, amount: { __typename: 'BtcAmount', btc: Satoshis } | { __typename: 'UsdAmount', usd: UsdCents } } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, startCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } } | null };
 
+export type LedgerAccountNameFragment = { __typename?: 'LedgerAccount', id: string, name: string, code?: any | null, ancestors: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }> };
+
+export type LedgerAccountNameByCodeQueryVariables = Exact<{
+  code: Scalars['String']['input'];
+}>;
+
+
+export type LedgerAccountNameByCodeQuery = { __typename?: 'Query', ledgerAccountByCode?: { __typename?: 'LedgerAccount', id: string, name: string, code?: any | null, ancestors: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }> } | null };
+
+export type LedgerAccountNameByIdQueryVariables = Exact<{
+  id: Scalars['UUID']['input'];
+}>;
+
+
+export type LedgerAccountNameByIdQuery = { __typename?: 'Query', ledgerAccount?: { __typename?: 'LedgerAccount', id: string, name: string, code?: any | null, ancestors: Array<{ __typename?: 'LedgerAccount', id: string, name: string, code?: any | null }> } | null };
+
 export type LedgerTransactionQueryVariables = Exact<{
   id: Scalars['UUID']['input'];
 }>;
@@ -3031,6 +3047,18 @@ export const LedgerAccountDetailsFragmentDoc = gql`
       hasNextPage
       hasPreviousPage
     }
+  }
+}
+    `;
+export const LedgerAccountNameFragmentDoc = gql`
+    fragment LedgerAccountName on LedgerAccount {
+  id
+  name
+  code
+  ancestors {
+    id
+    name
+    code
   }
 }
     `;
@@ -5307,6 +5335,86 @@ export type LedgerAccountQueryHookResult = ReturnType<typeof useLedgerAccountQue
 export type LedgerAccountLazyQueryHookResult = ReturnType<typeof useLedgerAccountLazyQuery>;
 export type LedgerAccountSuspenseQueryHookResult = ReturnType<typeof useLedgerAccountSuspenseQuery>;
 export type LedgerAccountQueryResult = Apollo.QueryResult<LedgerAccountQuery, LedgerAccountQueryVariables>;
+export const LedgerAccountNameByCodeDocument = gql`
+    query LedgerAccountNameByCode($code: String!) {
+  ledgerAccountByCode(code: $code) {
+    ...LedgerAccountName
+  }
+}
+    ${LedgerAccountNameFragmentDoc}`;
+
+/**
+ * __useLedgerAccountNameByCodeQuery__
+ *
+ * To run a query within a React component, call `useLedgerAccountNameByCodeQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLedgerAccountNameByCodeQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useLedgerAccountNameByCodeQuery({
+ *   variables: {
+ *      code: // value for 'code'
+ *   },
+ * });
+ */
+export function useLedgerAccountNameByCodeQuery(baseOptions: Apollo.QueryHookOptions<LedgerAccountNameByCodeQuery, LedgerAccountNameByCodeQueryVariables> & ({ variables: LedgerAccountNameByCodeQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<LedgerAccountNameByCodeQuery, LedgerAccountNameByCodeQueryVariables>(LedgerAccountNameByCodeDocument, options);
+      }
+export function useLedgerAccountNameByCodeLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LedgerAccountNameByCodeQuery, LedgerAccountNameByCodeQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<LedgerAccountNameByCodeQuery, LedgerAccountNameByCodeQueryVariables>(LedgerAccountNameByCodeDocument, options);
+        }
+export function useLedgerAccountNameByCodeSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<LedgerAccountNameByCodeQuery, LedgerAccountNameByCodeQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<LedgerAccountNameByCodeQuery, LedgerAccountNameByCodeQueryVariables>(LedgerAccountNameByCodeDocument, options);
+        }
+export type LedgerAccountNameByCodeQueryHookResult = ReturnType<typeof useLedgerAccountNameByCodeQuery>;
+export type LedgerAccountNameByCodeLazyQueryHookResult = ReturnType<typeof useLedgerAccountNameByCodeLazyQuery>;
+export type LedgerAccountNameByCodeSuspenseQueryHookResult = ReturnType<typeof useLedgerAccountNameByCodeSuspenseQuery>;
+export type LedgerAccountNameByCodeQueryResult = Apollo.QueryResult<LedgerAccountNameByCodeQuery, LedgerAccountNameByCodeQueryVariables>;
+export const LedgerAccountNameByIdDocument = gql`
+    query LedgerAccountNameById($id: UUID!) {
+  ledgerAccount(id: $id) {
+    ...LedgerAccountName
+  }
+}
+    ${LedgerAccountNameFragmentDoc}`;
+
+/**
+ * __useLedgerAccountNameByIdQuery__
+ *
+ * To run a query within a React component, call `useLedgerAccountNameByIdQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLedgerAccountNameByIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useLedgerAccountNameByIdQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useLedgerAccountNameByIdQuery(baseOptions: Apollo.QueryHookOptions<LedgerAccountNameByIdQuery, LedgerAccountNameByIdQueryVariables> & ({ variables: LedgerAccountNameByIdQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<LedgerAccountNameByIdQuery, LedgerAccountNameByIdQueryVariables>(LedgerAccountNameByIdDocument, options);
+      }
+export function useLedgerAccountNameByIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LedgerAccountNameByIdQuery, LedgerAccountNameByIdQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<LedgerAccountNameByIdQuery, LedgerAccountNameByIdQueryVariables>(LedgerAccountNameByIdDocument, options);
+        }
+export function useLedgerAccountNameByIdSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<LedgerAccountNameByIdQuery, LedgerAccountNameByIdQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<LedgerAccountNameByIdQuery, LedgerAccountNameByIdQueryVariables>(LedgerAccountNameByIdDocument, options);
+        }
+export type LedgerAccountNameByIdQueryHookResult = ReturnType<typeof useLedgerAccountNameByIdQuery>;
+export type LedgerAccountNameByIdLazyQueryHookResult = ReturnType<typeof useLedgerAccountNameByIdLazyQuery>;
+export type LedgerAccountNameByIdSuspenseQueryHookResult = ReturnType<typeof useLedgerAccountNameByIdSuspenseQuery>;
+export type LedgerAccountNameByIdQueryResult = Apollo.QueryResult<LedgerAccountNameByIdQuery, LedgerAccountNameByIdQueryVariables>;
 export const LedgerTransactionDocument = gql`
     query LedgerTransaction($id: UUID!) {
   ledgerTransaction(id: $id) {

--- a/apps/admin-panel/lib/utils.ts
+++ b/apps/admin-panel/lib/utils.ts
@@ -217,3 +217,27 @@ export const removeUnderscore = (str: string | undefined) => {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ")
 }
+
+/**
+ * Calls a function after {wait} time has passed
+ *
+ * @param callback - The function which we want to call
+ * @param wait - The amount of milliseconds to wait
+ * @param [immediate] - Whether to make an immediate call to the function
+ * @returns The function which will be called
+ */
+export const debounce = <T extends (args: Parameters<T>) => ReturnType<T>>(
+  callback: T,
+  wait: number,
+  immediate: boolean = false,
+) => {
+  let timeout: ReturnType<typeof setTimeout> | null
+  return function (callbackParams: Parameters<T>) {
+    if (timeout) clearTimeout(timeout)
+    if (immediate && !timeout) callback(callbackParams)
+    timeout = setTimeout(() => {
+      timeout = null
+      if (!immediate) callback(callbackParams)
+    }, wait)
+  }
+}

--- a/apps/admin-panel/messages/en.json
+++ b/apps/admin-panel/messages/en.json
@@ -1458,7 +1458,13 @@
       },
       "placeholders": {
         "accountSearch": "Ledger Account ID"
+      },
+      "errors": {
+        "accountSearch": "No account with that ID found"
       }
+    },
+    "searchResult": {
+      "title": "Account Found"
     }
   },
   "ManualTransactions": {

--- a/apps/admin-panel/messages/es.json
+++ b/apps/admin-panel/messages/es.json
@@ -1459,6 +1459,12 @@
       "placeholders": {
         "accountSearch": "ID de Cuenta del Libro Mayor"
       }
+      "errors": {
+        "accountSearch": "No encontramos una cuenta con esa ID"
+      }
+    },
+    "searchResult": {
+      "title": "Cuenta"
     }
   },
   "ManualTransactions": {


### PR DESCRIPTION
Stacks on top of the work in this PR https://github.com/GaloyMoney/lana-bank/pull/1841/files#diff-02854e0f47b5e3d309ac4eda820e29227f48afb784bc993cbad162c0420f8dde
Once merged I can point this work to the galoy repo. I usually stack PR changes so the conversations can remain to narrow and relevant topics. However, I haven't migrated this workflow to a forked repo and I am dealing with that currently.

This work adds a query functionality from within the index page of `/admin/ledger-account`. It provides a preview of the name of the account which the user can click on. The loading spinner component seems to not be rendering correctly, though it does seem to show. I can look at that in a new stack. 